### PR TITLE
Add Uses and About Pages

### DIFF
--- a/studio/schemas/documents/page.js
+++ b/studio/schemas/documents/page.js
@@ -16,6 +16,11 @@ export default {
         source: 'title',
         maxLength: 96
       }
+    },
+    {
+      name: 'body',
+      type: 'bodyPortableText',
+      title: 'Body'
     }
   ]
 }

--- a/web/src/components/header.js
+++ b/web/src/components/header.js
@@ -19,6 +19,9 @@ const Header = ({onHideNav, onShowNav, showNav, siteTitle}) => (
       <nav className={cn(styles.nav, showNav && styles.showNav)}>
         <ul>
           <li>
+            <Link to='/uses/'>Uses</Link>
+          </li>
+          <li>
             <Link to='/archive/'>Archive</Link>
           </li>
         </ul>

--- a/web/src/components/header.js
+++ b/web/src/components/header.js
@@ -19,6 +19,9 @@ const Header = ({onHideNav, onShowNav, showNav, siteTitle}) => (
       <nav className={cn(styles.nav, showNav && styles.showNav)}>
         <ul>
           <li>
+            <Link to='/about/'>About</Link>
+          </li>
+          <li>
             <Link to='/uses/'>Uses</Link>
           </li>
           <li>

--- a/web/src/pages/about.js
+++ b/web/src/pages/about.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import {graphql} from 'gatsby'
+import Container from '../components/container'
+import GraphQLErrorList from '../components/graphql-error-list'
+import SEO from '../components/seo'
+import Layout from '../containers/layout'
+import {responsiveTitle1} from '../components/typography.module.css'
+import PortableText from '../components/portableText'
+
+export const query = graphql`
+  query AboutPageQuery {
+        sanityPage(slug:{current:{eq:"about"}}) {
+          title
+          _rawBody
+        }
+    }
+`
+
+const AboutPage = props => {
+  const {data, errors} = props
+
+  if (errors) {
+    return (
+      <Layout>
+        <GraphQLErrorList errors={errors} />
+      </Layout>
+    )
+  }
+  return (
+    <Layout>
+      <SEO title='About' />
+      <Container>
+        <h1 className={responsiveTitle1}> {data.sanityPage.title} </h1>
+        <PortableText
+          blocks={data.sanityPage._rawBody}
+        />
+      </Container>
+    </Layout>
+  )
+}
+
+export default AboutPage

--- a/web/src/pages/uses.js
+++ b/web/src/pages/uses.js
@@ -4,19 +4,19 @@ import Container from '../components/container'
 import GraphQLErrorList from '../components/graphql-error-list'
 import SEO from '../components/seo'
 import Layout from '../containers/layout'
-
 import {responsiveTitle1} from '../components/typography.module.css'
+import PortableText from '../components/portableText'
 
 export const query = graphql`
   query UsesPageQuery {
         sanityPage(slug:{current:{eq:"uses"}}) {
           title
-            body {
-              _key
-              _type
-              style
-              list
-            }
+          body {
+            _key
+            _type
+            style
+            list
+          }
         }
     }
 `
@@ -36,7 +36,9 @@ const UsesPage = props => {
       <SEO title='Uses' />
       <Container>
         <h1 className={responsiveTitle1}>{data.sanityPage.title}</h1>
-        {/* TODO: Insert Portable Text from Body */}
+        <PortableText
+          blocks={data.sanityPage.body}
+        />
         <pre>{JSON.stringify(data, null, 2)}</pre>
       </Container>
     </Layout>

--- a/web/src/pages/uses.js
+++ b/web/src/pages/uses.js
@@ -11,6 +11,12 @@ export const query = graphql`
   query UsesPageQuery {
         sanityPage(slug:{current:{eq:"uses"}}) {
           title
+            body {
+              _key
+              _type
+              style
+              list
+            }
         }
     }
 `
@@ -29,7 +35,8 @@ const UsesPage = props => {
     <Layout>
       <SEO title='Uses' />
       <Container>
-        <h1 className={responsiveTitle1}>Uses</h1>
+        <h1 className={responsiveTitle1}>{data.sanityPage.title}</h1>
+        {/* TODO: Insert Portable Text from Body */}
         <pre>{JSON.stringify(data, null, 2)}</pre>
       </Container>
     </Layout>

--- a/web/src/pages/uses.js
+++ b/web/src/pages/uses.js
@@ -11,12 +11,7 @@ export const query = graphql`
   query UsesPageQuery {
         sanityPage(slug:{current:{eq:"uses"}}) {
           title
-          body {
-            _key
-            _type
-            style
-            list
-          }
+          _rawBody
         }
     }
 `
@@ -35,11 +30,10 @@ const UsesPage = props => {
     <Layout>
       <SEO title='Uses' />
       <Container>
-        <h1 className={responsiveTitle1}>{data.sanityPage.title} Test</h1>
+        <h1 className={responsiveTitle1}> {data.sanityPage.title} </h1>
         <PortableText
-          blocks={data.sanityPage.body}
+          blocks={data.sanityPage._rawBody}
         />
-        <pre>{JSON.stringify(data, null, 2)}</pre>
       </Container>
     </Layout>
   )

--- a/web/src/pages/uses.js
+++ b/web/src/pages/uses.js
@@ -35,7 +35,7 @@ const UsesPage = props => {
     <Layout>
       <SEO title='Uses' />
       <Container>
-        <h1 className={responsiveTitle1}>{data.sanityPage.title}</h1>
+        <h1 className={responsiveTitle1}>{data.sanityPage.title} Test</h1>
         <PortableText
           blocks={data.sanityPage.body}
         />


### PR DESCRIPTION
I've built two new pages `Uses` and `About`. 

- Setup two new pages in Sanity: Uses and About
- Created two front-end Gatsby pages `uses.js` and `about.js` that both pull from Sanity and display the raw text